### PR TITLE
Fix modules to pass 'puppet parser validate'

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -2,9 +2,9 @@ class lemonldap::server($domain,$webserver) {
 
     # Execute OS specific actions
     case $::osfamily {
-        'Debian':    { include lemonldap::server::operatingsystem::debian($webserver) }
-        'RedHat':    { include lemonldap::server::operatingsystem::redhat($webserver) }
-        default:
+        'Debian': { include lemonldap::server::operatingsystem::debian($webserver) }
+        'RedHat': { include lemonldap::server::operatingsystem::redhat($webserver) }
+        default: { fail("Module ${module_name} is not supported on ${::operatingsystem}") }
     }
 
     # LemonLDAP packages
@@ -17,9 +17,9 @@ class lemonldap::server($domain,$webserver) {
     }
 
     case $webserver {
-        'apache':       { include lemonldap::server::webserver::apache($webserverpath,$domain) }
-        'nginx' :       { include lemonldap::server::webserver::nginx($webserverpath,$domain) }
-        default:
+        'apache': { include lemonldap::server::webserver::apache($domain) }
+        'nginx' : { include lemonldap::server::webserver::nginx($domain) }
+        default: { fail("Module ${module_name} needs apache or nginx webserver") }
     }
 
     # Set reload vhost in /etc/hosts

--- a/manifests/server/operatingsystem/debian.pp
+++ b/manifests/server/operatingsystem/debian.pp
@@ -1,14 +1,10 @@
 class lemonldap::server::operatingsystem::debian($webserver) {
 
-    $apachegroup = 'www-data';
-
     if $webserver == 'nginx' {
         $packageswebserver = ['nginx','nginx-extras', 'lemonldap-ng-fastcgi-server']
-        $lemonldap::server::webserverpath = "/etc/nginx"
     }
     elsif $webserver == 'apache' {
         $packageswebserver = ['apache2','libapache2-mod-perl2','libapache2-mod-fcgid']
-        $lemonldap::server::webserverpath = "/etc/apache2"
     }
 
     file{ 'repository_debian':

--- a/manifests/server/operatingsystem/redhat.pp
+++ b/manifests/server/operatingsystem/redhat.pp
@@ -1,14 +1,10 @@
 class lemonldap::server::operatingsystem::redhat($webserver) {
 
-    $apachegroup = 'apache';
-
     if $webserver == 'nginx' {
         $packageswebserver = ['nginx', 'lemonldap-ng-fastcgi-server']
-        $lemonldap::server::webserverpath = "/etc/nginx"
     }
     elsif $webserver == 'apache' {
         $packageswebserver = ['httpd','mod_perl','mod_fcgid']
-        $lemonldap::server::webserverpath = "/etc/httpd"
     }
 
     file{ 'repository_redhat':

--- a/manifests/server/webserver/apache.pp
+++ b/manifests/server/webserver/apache.pp
@@ -1,4 +1,4 @@
-class lemonldap::server::webserver::apache($webserverpath,$domain) {
+class lemonldap::server::webserver::apache($domain) {
 
     augeas{ "handlerapache":
         context => '/files/etc/lemonldap/handler-apache2.conf',
@@ -28,7 +28,7 @@ class lemonldap::server::webserver::apache($webserverpath,$domain) {
         changes => [
             'set ServerName test1.$domain',
             'set ServerAlias test2.$domain',
-            ]
+            ],
         onlyif  => 'values "ServerName" != "test1.$domain"',
     }
 

--- a/manifests/server/webserver/nginx.pp
+++ b/manifests/server/webserver/nginx.pp
@@ -1,4 +1,4 @@
-class lemonldap::server::webserver::nginx($webserverpath,$domain) {
+class lemonldap::server::webserver::nginx($domain) {
 
     augeas{ "handlernginx":
         context => '/files/etc/lemonldap/handler-nginx.conf',


### PR DESCRIPTION
The proposed modules were not valid (a lot of error when running puppet parser validate).

I also removed unused variable $webserverpath.